### PR TITLE
feat: Allow kinesis to be an optional feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ See documentation here: [aws-databricks/README.md](aws-databricks/README.md)
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.73.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.74.3 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.1.0 |
 
 ## Modules
@@ -43,6 +43,7 @@ See documentation here: [aws-databricks/README.md](aws-databricks/README.md)
 | <a name="input_databricks_account_id"></a> [databricks\_account\_id](#input\_databricks\_account\_id) | Databricks Account ID | `any` | n/a | yes |
 | <a name="input_databricks_account_password"></a> [databricks\_account\_password](#input\_databricks\_account\_password) | Databricks Account Password | `any` | n/a | yes |
 | <a name="input_databricks_account_username"></a> [databricks\_account\_username](#input\_databricks\_account\_username) | Databricks Account Username | `any` | n/a | yes |
+| <a name="input_enable_kinesis"></a> [enable\_kinesis](#input\_enable\_kinesis) | Enable Kinesis for use with databricks (alternatively, you can use apache kafka) | `bool` | `false` | no |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | Prefix for databricks which is required so databricks can see resources. Can be prefixed as `prefix-someotherstring` | `any` | n/a | yes |
 | <a name="input_private_subnet_ids"></a> [private\_subnet\_ids](#input\_private\_subnet\_ids) | Private Subnet IDs used for databricks to know where to deploy ec2 instances | `set(string)` | n/a | yes |
 | <a name="input_public_subnet_id"></a> [public\_subnet\_id](#input\_public\_subnet\_id) | Public Subnet ID used for creating igw | `string` | n/a | yes |

--- a/aws-databricks/README.md
+++ b/aws-databricks/README.md
@@ -135,8 +135,13 @@ module "aws-databricks" {
   private_subnet_ids = var.private_subnet_ids
 
   public_subnet_id = var.public_subnet_id
+
+  enable_kinesis = var.enable_kinesis
 }
 ```
+
+Note:
+Kinesis is an optional feature. If you enable it, you must have a Kinesis stream.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements

--- a/aws-databricks/infra.tf
+++ b/aws-databricks/infra.tf
@@ -199,7 +199,19 @@ module "vpc_endpoints" {
       tags = {
         Name = "${var.prefix}-sts-vpc-endpoint"
       }
-    },
+    }
+  }
+}
+
+module "vpc_kinesis_endpoint" {
+  count = var.enable_kinesis ? 1 : 0
+
+  source  = "terraform-aws-modules/vpc/aws//modules/vpc-endpoints"
+  version = "3.2.0"
+
+  vpc_id             = var.vpc_id
+  security_group_ids = [aws_security_group.databricks_sg.id]
+  endpoints = {
     kinesis-streams = {
       service             = "kinesis-streams"
       private_dns_enabled = true
@@ -207,6 +219,6 @@ module "vpc_endpoints" {
       tags = {
         Name = "${var.prefix}-kinesis-vpc-endpoint"
       }
-    },
+    }
   }
 }

--- a/aws-databricks/variables.tf
+++ b/aws-databricks/variables.tf
@@ -50,3 +50,9 @@ variable "igw_id" {
   type        = string
   default     = null
 }
+
+variable "enable_kinesis" {
+  description = "Enable Kinesis for use with databricks (alternative is to use apache kafka)"
+  type        = bool
+  default     = false
+}

--- a/main.tf
+++ b/main.tf
@@ -170,4 +170,6 @@ module "aws-databricks" {
   private_subnet_ids = var.private_subnet_ids
 
   public_subnet_id = var.public_subnet_id
+
+  enable_kinesis = var.enable_kinesis
 }

--- a/variables.tf
+++ b/variables.tf
@@ -40,3 +40,9 @@ variable "public_subnet_id" {
 variable "prefix" {
   description = "Prefix for databricks which is required so databricks can see resources. Can be prefixed as `prefix-someotherstring`"
 }
+
+variable "enable_kinesis" {
+  description = "Enable Kinesis for use with databricks (alternatively, you can use apache kafka)"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
* Since Kinesis is an optional feature and not a hard dependency of Databricks, we should allow users to choose whether they wish to enable this as part of deploying Databricks or not. 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/terraform-aws-databricks/6)
<!-- Reviewable:end -->
